### PR TITLE
feat: theme setting to hide prices of sold out products

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -60,11 +60,13 @@
                   <div class="product-list-thumb-info">
                     <div class="product-list-thumb-name">{{ product.name }}</div>
                     <div class="product-list-thumb-price">
-                      {% if product.variable_pricing %}
-                        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                      {% else %}
-                        {{ product.default_price | money: theme.money_format }}
-                      {% endif %}
+                      {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                        {% if product.variable_pricing %}
+                          {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                        {% else %}
+                          {{ product.default_price | money: theme.money_format }}
+                        {% endif %}
+                      {% endunless %}
                     </div>
                     {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
                   </div>

--- a/source/product.html
+++ b/source/product.html
@@ -8,6 +8,12 @@
 		{% assign product_status = 'Coming soon' %}
 {% endcase %}
 
+{% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+  {% assign hide_price = true %}
+{% else %}
+  {% assign hide_price = false %}
+{% endif %}
+
 {% if product.categories != blank %}
   <nav class="product-breadcrumb" role="navigation" aria-label="breadcrumbs">
     <a href="/products">{{ pages.products.name }}</a> / {{ product.categories.first | link_to }}
@@ -121,14 +127,16 @@
   <section class="product-detail">
     <div class="product-detail__header">
       {% capture product_pricing %}
-        {% if product.variable_pricing %}
-          {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-        {% else %}
-          {{ product.default_price | money: theme.money_format }}
-        {% endif %}
+        {% unless hide_price %}
+          {% if product.variable_pricing %}
+            {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+          {% else %}
+            {{ product.default_price | money: theme.money_format }}
+          {% endif %}
+        {% endunless %}
       {% endcapture %}
       <h1 class="page-title page-title--left product-detail__title">{{ product.name }}</h1>
-      <div class="product-detail__pricing">{{ product_pricing }} {% if product_status != blank %}<div class="product-detail__status">{{ product_status }}</div>{% endif %}</div>
+      <div class="product-detail__pricing">{{ product_pricing }} {% if product_status != blank %}<div class="product-detail__status {% unless hide_price %}with-spacing{% endunless %}">{{ product_status }}</div>{% endif %}</div>
     </div>
     {% if product.status == 'active' %}
       <form method="post" class="product-form {% if theme.show_sold_out_product_options %}show-sold-out{% else %}hide-sold-out{% endif %}" action="/cart" accept-charset="utf8">

--- a/source/products.html
+++ b/source/products.html
@@ -52,11 +52,13 @@
               <div class="product-list-thumb-info">
                 <div class="product-list-thumb-name">{{ product.name }}</div>
                 <div class="product-list-thumb-price">
-                  {% if product.variable_pricing %}
-                    {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                  {% else %}
-                    {{ product.default_price | money: theme.money_format }}
-                  {% endif %}
+                  {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% if product.variable_pricing %}
+                      {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                    {% else %}
+                      {{ product.default_price | money: theme.money_format }}
+                    {% endif %}
+                  {% endunless %}
                 </div>
                 {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
               </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Foundry",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "images": [
     {
       "variable": "header_logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -388,10 +388,18 @@
     },
     {
       "variable": "show_sold_out_product_options",
-      "label": "Show sold out product options",
+      "label": "Show sold out product variants",
       "type": "boolean",
       "default": true,
-      "description": "Shows sold out product options in the Product page dropdowns",
+      "description": "Shows sold out product variants in the Product page dropdowns",
+      "requires": "inventory"
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "type": "boolean",
+      "default": true,
+      "description": "Display prices for sold out products when they are visible",
       "requires": "inventory"
     },
     {

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -55,6 +55,10 @@
     flex-direction: column
     align-items: flex-start
 
+  &__title
+    line-height: 1.2
+    padding-bottom: 10px
+
   &__status
     text-transform: uppercase
     font-size: .825rem

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -62,10 +62,12 @@
     font-weight: 500
     display: inline-block
     padding: 4px 6px
-    margin-left: 8px
     border: 1px solid var(--border-color)
     border-radius: var(--border-radius)
     letter-spacing: 1.1px
+
+    &.with-spacing
+      margin-left: 8px
 
   &__pricing
     color: var(--secondary-text-color)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/93240c21-3a82-4fbf-9249-dc27269258b5)

Also snuck in a small tweak for line height of product title and spacing with the product status:

![image](https://github.com/user-attachments/assets/187e01f9-a402-4d42-ad5c-3f3eee1912e7)

![image](https://github.com/user-attachments/assets/cf7018b3-a063-4356-b57a-49ea7e23af79)
