### PR TITLE
feat: product status badge color

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -36,6 +36,7 @@
                 {% when 'coming-soon' %}
                   {% assign product_status = 'Coming soon' %}
               {% endcase %}
+              {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
               <div class="product-list-thumb {{ product.css_class }}">
                 <a class="product-list-link" href="{{ product.url }}" title="View {{ product.name | escape }}">
                   <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -55,7 +56,7 @@
                       "
                       data-sizes="auto"
                     >
-                    {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                    {% if product_status != blank %}<div class="product-list-thumb-status {{ status_class }}">{{ product_status }}</div>{% endif %}
                   </div>
                   <div class="product-list-thumb-info">
                     <div class="product-list-thumb-name">{{ product.name }}</div>
@@ -68,7 +69,7 @@
                         {% endif %}
                       {% endunless %}
                     </div>
-                    {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                    {% if product_status != blank %}<div class="product-list-thumb-status {{ status_class }}">{{ product_status }}</div>{% endif %}
                   </div>
                 </a>
               </div>

--- a/source/product.html
+++ b/source/product.html
@@ -135,8 +135,9 @@
           {% endif %}
         {% endunless %}
       {% endcapture %}
+      {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
       <h1 class="page-title page-title--left product-detail__title">{{ product.name }}</h1>
-      <div class="product-detail__pricing">{{ product_pricing }} {% if product_status != blank %}<div class="product-detail__status {% unless hide_price %}with-spacing{% endunless %}">{{ product_status }}</div>{% endif %}</div>
+      <div class="product-detail__pricing">{{ product_pricing }} {% if product_status != blank %}<div class="product-detail__status  {{ status_class }} {% unless hide_price %}with-spacing{% endunless %}">{{ product_status }}</div>{% endif %}</div>
     </div>
     {% if product.status == 'active' %}
       <form method="post" class="product-form {% if theme.show_sold_out_product_options %}show-sold-out{% else %}hide-sold-out{% endif %}" action="/cart" accept-charset="utf8">

--- a/source/products.html
+++ b/source/products.html
@@ -28,6 +28,7 @@
             {% when 'coming-soon' %}
               {% assign product_status = 'Coming soon' %}
           {% endcase %}
+          {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
           <div class="product-list-thumb {{ product.css_class }}">
             <a class="product-list-link" href="{{ product.url }}" title="View {{ product.name | escape }}">
               <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -47,7 +48,7 @@
                   "
                   data-sizes="auto"
                 >
-                {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                {% if product_status != blank %}<div class="product-list-thumb-status {{ status_class }}">{{ product_status }}</div>{% endif %}
               </div>
               <div class="product-list-thumb-info">
                 <div class="product-list-thumb-name">{{ product.name }}</div>
@@ -60,7 +61,7 @@
                     {% endif %}
                   {% endunless %}
                 </div>
-                {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                {% if product_status != blank %}<div class="product-list-thumb-status {{ status_class }}"">{{ product_status }}</div>{% endif %}
               </div>
             </a>
           </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -41,6 +41,10 @@
               "primary_text_color": "#222222",
               "secondary_text_color": "#555555",
               "link_hover_color": "#116E56",
+              "product_status_text_color_primary": "#222222",
+              "product_status_background_color_primary": "#E9C651",
+              "product_status_text_color_secondary": "#222222",
+              "product_status_background_color_secondary": "#FFFFFF",
               "footer_background_color": "#F9F9F9",
               "announcement_text_color": "#222222",
               "announcement_background_color": "#EEEEEE"
@@ -63,6 +67,10 @@
               "primary_text_color": "#111111",
               "secondary_text_color": "#111111",
               "link_hover_color": "#5900FF",
+              "product_status_text_color_primary": "#FFFFFF",
+              "product_status_background_color_primary": "#5900FF",
+              "product_status_text_color_secondary": "#111111",
+              "product_status_background_color_secondary": "#FFFFFF",
               "footer_background_color": "#FFFFFF",
               "announcement_text_color": "#111111",
               "announcement_background_color": "#F3F3F5"
@@ -90,6 +98,10 @@
               "primary_text_color": "#F8F8F8",
               "secondary_text_color": "#F8F8F8",
               "link_hover_color": "#C6C6C6",
+              "product_status_text_color_primary": "#F8F8F8",
+              "product_status_background_color_primary": "#141415",
+              "product_status_text_color_secondary": "#F8F8F8",
+              "product_status_background_color_secondary": "#FFFFFF",
               "footer_background_color": "#141415",
               "announcement_text_color": "#F8F8F8",
               "announcement_background_color": "#303030"
@@ -112,6 +124,10 @@
               "primary_text_color": "#0F1B27",
               "secondary_text_color": "#0F1B27",
               "link_hover_color": "#8A5A5A",
+              "product_status_text_color_primary": "#FFFFFF",
+              "product_status_background_color_primary": "#8A5A5A",
+              "product_status_text_color_secondary": "#0F1B27",
+              "product_status_background_color_secondary": "#F8F8F8",
               "footer_background_color": "#F8F8F8",
               "announcement_text_color": "#0F1B27",
               "announcement_background_color": "#EBE7E7"
@@ -139,6 +155,10 @@
               "primary_text_color": "#584B53",
               "secondary_text_color": "#584B53",
               "link_hover_color": "#9D5C63",
+              "product_status_text_color_primary": "#FFFDFC",
+              "product_status_background_color_primary": "#584B53",
+              "product_status_text_color_secondary": "#584B53",
+              "product_status_background_color_secondary": "#FFFDFC",
               "footer_background_color": "#FEF5EF",
               "announcement_text_color": "#584B53",
               "announcement_background_color": "#FEF5EF"
@@ -210,6 +230,26 @@
       "variable": "button_hover_background_color",
       "label": "Button background hover",
       "default": "#116E56"
+    },
+    {
+      "variable": "product_status_background_color_primary",
+      "label": "Product status background (Primary)",
+      "default": "#E9C651"
+    },
+    {
+      "variable": "product_status_text_color_primary",
+      "label": "Product status text (Primary)",
+      "default": "#222222"
+    },
+    {
+      "variable": "product_status_background_color_secondary",
+      "label": "Product status background (Secondary)",
+      "default": "#FFFFFF"
+    },
+    {
+      "variable": "product_status_text_color_secondary",
+      "label": "Product status text (Secondary)",
+      "default": "#222222"
     },
     {
       "variable": "footer_background_color",

--- a/source/stylesheets/_header.sass
+++ b/source/stylesheets/_header.sass
@@ -150,7 +150,7 @@
     display: flex
     line-height: 1.25em
     align-items: center
-    max-width: 200px
+    max-width: 350px
     padding: 8px 0
     width: auto
     outline-offset: 4px

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -27,8 +27,10 @@
   --error-background-color: #950f1e
   --error-text-color: #FFFFFF
 
-  --product-status-background-color: var(--background-color)
-  --product-status-text-color: var(--primary-text-color)
+  --product-status-background-color-primary: #{"{{ theme.product_status_background_color_primary }}"}
+  --product-status-text-color-primary: #{"{{ theme.product_status_text_color_primary }}"}
+  --product-status-background-color-secondary: #{"{{ theme.product_status_background_color_secondary }}"}
+  --product-status-text-color-secondary: #{"{{ theme.product_status_text_color_secondary }}"}
 
   --border-radius: #{'{{ theme.border_radius }}'}
   --header-height: 90px

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -98,9 +98,7 @@ a.product-list-link
     object-fit: contain
 
 .product-list-thumb-status
-  background: var(--product-status-background-color)
   border-radius: var(--border-radius)
-  color: var(--product-status-text-color)
   top: 12px
   right: 12px
   font-size: .875rem
@@ -111,6 +109,14 @@ a.product-list-link
   text-transform: uppercase
   padding: 6px
   z-index: 2
+
+  &.status-primary
+    background: var(--product-status-background-color-primary)
+    color: var(--product-status-text-color-primary)
+
+  &.status-secondary
+    background: var(--product-status-background-color-secondary)
+    color: var(--product-status-text-color-secondary)
 
 .product-list-thumb-info
   line-height: normal


### PR DESCRIPTION
Add setting to control the product status background and text color instead of it always being theme background and primary text color. The primary color is used only for on sale status since that is the most important status to draw attention to.

Adjusted the style presets to choose color patterns that were complimentary.

![image](https://github.com/user-attachments/assets/f3dc57f2-163c-4f44-9a7c-c7537b42dc62)

![image](https://github.com/user-attachments/assets/90e3294c-d391-4ca2-8705-c6ab010730a8)


Also snuck in fix to bump max width of store name in header from 200px to 350px:

![image](https://github.com/user-attachments/assets/b682bc59-776b-436f-99a6-019d58b47ce0)
