### PR TITLE
Foundry 2.8.1

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Foundry",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "images": [
     {
       "variable": "header_logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -589,18 +589,6 @@
       "description": "Choose how your custom pages appear in your shop's header menu."
     },
     {
-      "variable": "pages_global_nav_dropdown_text",
-      "label": "Custom pages header dropdown text",
-      "section": "global_navigation",
-      "type": "text",
-      "default": "More",
-      "max_length": 25,
-      "description": "The label for your dropdown menu containing custom pages",
-      "requires": [
-        "pages_global_nav_style eq dropdown"
-      ]
-    },
-    {
       "variable": "nav_items",
       "label": "Navigation items",
       "section": "global_navigation",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1619,6 +1619,7 @@
       "section": "translations",
       "sub_section": "cart",
       "type": "text",
+      "max_length": 250,
       "default": "Your cart is empty",
       "description": "Text for the empty cart message",
       "requires": [ "translation_mode eq manual" ]


### PR DESCRIPTION
- fix: remove unnecessary setting left over from translations work that is no longer relevant
- feat: extend empty cart text to 250 chars